### PR TITLE
Basis expansion method for time-propagation

### DIFF
--- a/input.dat
+++ b/input.dat
@@ -15,6 +15,7 @@
 5  300                              ! Ncg ,Nscf (# of CG method,# of ground state iteration)
 2000  0.04  0                        ! Nt,dt,Npred_corr real-time parameter
 'N'  600                             ! option_TD_band_dos, Nstep_TD_band_dos ('Y' or 'N')
+'N'                                 ! option_IP ('Y' or 'N')
 0.001                               ! dAc (initial distortion in response)
 'cos4cos'  'Tr'                          ! laser_type 'cos2cos', 'cos4cos' or 'impulse',  Tr_Lo 'Tr' or 'Lo'
 1d13  10.0  1.55  .0                ! IWcm2_1, tpulsefs_1(fs), omegaev_1(eV), phi_CEP_1(2pi) :laser

--- a/src/BE_current.f90
+++ b/src/BE_current.f90
@@ -1,0 +1,76 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine BE_current(jav,Act_t)
+  use global_variables
+  use PSE_variables
+  implicit none
+  real(8) :: jav,Act_t
+  real(8) :: jav_l
+  integer :: iav, iav_t
+  real(8) :: diff,xx
+
+  integer :: ik,ib,i,ix,iy,iz,ilma,ia,j
+  real(8) :: x1,x2,x3,jxt,jyt,jzt,jx1t,jx2t,jx3t,x,y,z
+  complex(8) :: uVpsi,uVpsix,uVpsiy,uVpsiz
+  real(8) :: curr(3),curr_l(3)
+  real(8) :: curr_Lvec(3),curr_l_Lvec(3)
+  complex(8) :: zt(3)
+  real(8) :: bb1,bb2,bb3
+  real(8) :: jx1,jx2,jx3
+
+!  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
+!  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
+!  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
+
+!== construct current matrix start
+  diff = 1d10
+  do iav = -NAmax,NAmax
+    if( abs(Act_t-dble(iav)*dAmax) < diff)then
+      diff = abs(Act_t-dble(iav)*dAmax)
+      iav_t = iav
+    end if
+  end do
+  if(abs(iav_t) == NAmax)then
+    err_message='Amax is too small.'
+    call err_finalize
+  end if
+
+  xx = (Act_t-dble(iav_t)*dAmax)/dAmax
+  zPi_tot(:,:,:) = 0.5d0*zPi_NL(:,:,:,iav_t+1)*(xx**2+xx) &
+                  +0.5d0*zPi_NL(:,:,:,iav_t-1)*(xx**2-xx) &
+                  +      zPi_NL(:,:,:,iav_t)*(1d0 - xx**2)
+  zPi_tot = zPi_tot + zPi_loc
+  do ib = 1,NB_basis
+    zPi_tot(ib,ib,:) = zPi_tot(ib,ib,:) + Act_t
+  end do
+!== construct current matrix end
+
+  jav_l = 0d0
+  K_point : do ik=NK_s,NK_e
+  Band : do ib=1,NB_TD
+
+    zACt_tmp(:) = matmul(zPi_tot(:,:,ik),zCt(:,ib,ik))
+    jav_l = jav_l + occ(ib,ik)*sum(conjg(zCt(:,ib,ik))*zACt_tmp(:))
+
+  end do Band
+  end do K_point
+
+  jav_l=jav_l/Vcell
+
+  call MPI_ALLREDUCE(jav_l,jav,1,MPI_REAL8,MPI_SUM,NEW_COMM_WORLD,ierr)  
+
+  return
+end subroutine BE_current

--- a/src/BE_current.f90
+++ b/src/BE_current.f90
@@ -21,15 +21,7 @@ subroutine BE_current(jav,Act_t)
   real(8) :: jav_l
   integer :: iav, iav_t
   real(8) :: diff,xx
-
-  integer :: ik,ib,i,ix,iy,iz,ilma,ia,j
-  real(8) :: x1,x2,x3,jxt,jyt,jzt,jx1t,jx2t,jx3t,x,y,z
-  complex(8) :: uVpsi,uVpsix,uVpsiy,uVpsiz
-  real(8) :: curr(3),curr_l(3)
-  real(8) :: curr_Lvec(3),curr_l_Lvec(3)
-  complex(8) :: zt(3)
-  real(8) :: bb1,bb2,bb3
-  real(8) :: jx1,jx2,jx3
+  integer :: ik,ib
 
 !  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
 !  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)

--- a/src/BE_dt_evolve.f90
+++ b/src/BE_dt_evolve.f90
@@ -1,0 +1,65 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine BE_dt_evolve(Act_t)
+  use global_variables
+  use PSE_variables
+  real(8) :: Act_t
+  integer :: iav, iav_t
+  real(8) :: diff,xx
+  integer :: ik,ib,iexp
+  complex(8) :: zfact
+
+!== construct current matrix start
+  diff = 1d10
+  do iav = -NAmax,NAmax
+    if( abs(Act_t-dble(iav)*dAmax) < diff)then
+      diff = abs(Act_t-dble(iav)*dAmax)
+      iav_t = iav
+    end if
+  end do
+  if(abs(iav_t) == NAmax)then
+    err_message='Amax is too small.'
+    call err_finalize
+  end if
+
+  xx = (Act_t-dble(iav_t)*dAmax)/dAmax
+  zH_tot(:,:,:) = 0.5d0*zV_NL(:,:,:,iav_t+1)*(xx**2+xx) &
+                  +0.5d0*zV_NL(:,:,:,iav_t-1)*(xx**2-xx) &
+                  +      zV_NL(:,:,:,iav_t)*(1d0 - xx**2)
+  zH_tot = zH_tot + zH_loc + zPi_loc*Act_t
+  do ib = 1,NB_basis
+    zH_tot(ib,ib,:) = zH_tot(ib,ib,:) + 0.5d0*Act_t**2
+  end do
+!== construct current matrix end
+
+  K_point : do ik=NK_s,NK_e
+  Band : do ib=1,NB_TD
+
+    zfact = 1d0
+    ztCt_tmp(:)=zCt(:,ib,ik)
+    do iexp = 1,4
+      zfact = zfact*(-zI*dt)/dble(iexp)
+      zACt_tmp(:) = matmul(zH_tot(:,:,ik),ztCt_tmp(:))
+      zCt(:,ib,ik) = zCt(:,ib,ik) + zfact*zACt_tmp(:)
+      ztCt_tmp(:) = zACt_tmp(:)
+    end do
+
+  end do Band
+  end do K_point
+
+  return
+end subroutine BE_dt_evolve
+  

--- a/src/PSE_Pinlpsi.f90
+++ b/src/PSE_Pinlpsi.f90
@@ -1,0 +1,44 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_Pinlpsi(ik)
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: ik
+  integer :: i,ix,iy,iz
+  integer :: ilma,ia,j
+  complex(8) :: uVpsi
+
+  htpsi= 0d0 !htpsi+(Vloc+kAc2_2)*tpsi
+
+!  return
+!Calculating nonlocal part
+  do ilma=1,Nlma
+    ia=a_tbl(ilma)
+    uVpsi=0.d0
+    do j=1,Mps(ia)
+      i=Jxyz(j,ia)
+      uVpsi=uVpsi+uV(j,ilma)*ekr(j,ia,ik)*tpsi(i)
+    enddo
+    uVpsi=uVpsi*H123*iuV(ilma)
+    do j=1,Mps(ia)
+      i=Jxyz(j,ia)
+      htpsi(i)=htpsi(i)+conjg(ekr(j,ia,ik))*uVpsi*uV(j,ilma)
+    enddo
+  enddo
+
+  return
+end subroutine PSE_Pinlpsi

--- a/src/PSE_Vnlpsi.f90
+++ b/src/PSE_Vnlpsi.f90
@@ -1,0 +1,44 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_Vnlpsi(ik)
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: ik
+  integer :: i,ix,iy,iz
+  integer :: ilma,ia,j
+  complex(8) :: uVpsi
+
+  htpsi= 0d0 !htpsi+(Vloc+kAc2_2)*tpsi
+
+!  return
+!Calculating nonlocal part
+  do ilma=1,Nlma
+    ia=a_tbl(ilma)
+    uVpsi=0.d0
+    do j=1,Mps(ia)
+      i=Jxyz(j,ia)
+      uVpsi=uVpsi+uV(j,ilma)*ekr(j,ia,ik)*tpsi(i)
+    enddo
+    uVpsi=uVpsi*H123*iuV(ilma)
+    do j=1,Mps(ia)
+      i=Jxyz(j,ia)
+      htpsi(i)=htpsi(i)+conjg(ekr(j,ia,ik))*uVpsi*uV(j,ilma)
+    enddo
+  enddo
+
+  return
+end subroutine PSE_Vnlpsi

--- a/src/PSE_dt_evolve_IP.f90
+++ b/src/PSE_dt_evolve_IP.f90
@@ -1,0 +1,32 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_dt_evolve_IP(iter)
+  use global_variables
+  use PSE_variables
+  integer :: iter,ipred_corr
+  integer :: iexp
+
+
+  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+0.5d0*(Actot_Cvec(1,iter)+Actot_Cvec(1,iter+1))
+  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+0.5d0*(Actot_Cvec(2,iter)+Actot_Cvec(2,iter+1))
+  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+0.5d0*(Actot_Cvec(3,iter)+Actot_Cvec(3,iter+1))
+
+  call PSE_pre_hpsi
+  call PSE_Taylor
+
+  return
+end subroutine PSE_dt_evolve_IP
+  

--- a/src/PSE_hpsi_loc.f90
+++ b/src/PSE_hpsi_loc.f90
@@ -1,0 +1,106 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_hpsi_loc(ik)
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: ik
+  integer :: i,ix,iy,iz
+  real(8) :: kAc2_2
+  integer :: ilma,ia,j
+  complex(8) :: uVpsi
+
+  kAc2_2=sum(kAc_Cvec(:,ik)**2)*0.5
+
+  do i=1,NL
+    zft2(iLx(1,i),iLx(2,i),iLx(3,i))=tpsi(i)
+  end do
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(cexp_x3(:,iz)*zft2(ix,iy,:))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(cexp_x2(:,iy)*zft1(ix,:,iz))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(cexp_x1(:,ix)*zft2(:,iy,iz))
+  end do
+  end do
+  end do
+
+  zft1(:,:,:)=(-0.5d0*Lap_k(:,:,:) &
+    -kAc_Cvec(1,ik)*Grad_x_zI(:,:,:) &
+    -kAc_Cvec(2,ik)*Grad_y_zI(:,:,:) &
+    -kAc_Cvec(3,ik)*Grad_z_zI(:,:,:) &
+    )*zft1(:,:,:)/dble(NL1*NL2*NL3)
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(exp_x3(:,iz)*zft1(ix,iy,:))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(exp_x2(:,iy)*zft2(ix,:,iz))
+  end do
+  end do
+  end do
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(exp_x1(:,ix)*zft1(:,iy,iz))
+  end do
+  end do
+  end do
+
+  do i=1,NL
+    htpsi(i)=zft2(iLx(1,i),iLx(2,i),iLx(3,i))
+  end do
+
+  htpsi=htpsi+(Vloc+kAc2_2)*tpsi
+
+  return
+!!Calculating nonlocal part
+!  do ilma=1,Nlma
+!    ia=a_tbl(ilma)
+!    uVpsi=0.d0
+!    do j=1,Mps(ia)
+!      i=Jxyz(j,ia)
+!      uVpsi=uVpsi+uV(j,ilma)*ekr(j,ia,ik)*tpsi(i)
+!    enddo
+!    uVpsi=uVpsi*H123*iuV(ilma)
+!    do j=1,Mps(ia)
+!      i=Jxyz(j,ia)
+!      htpsi(i)=htpsi(i)+conjg(ekr(j,ia,ik))*uVpsi*uV(j,ilma)
+!    enddo
+!  enddo
+
+  return
+end subroutine PSE_hpsi_loc

--- a/src/PSE_ppsi.f90
+++ b/src/PSE_ppsi.f90
@@ -1,0 +1,36 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_ppsi(ik)
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: ik
+
+
+  select case(type_spatial_difference)
+  case('FD')
+    err_message = 'type_spatial_difference=FD is not available for ppsi'
+    call err_finalize
+  case('FT')
+    call PSE_ppsi_DFT(ik)
+  case default
+    err_message = 'invalid parameter in type_spatial_difference'
+    call err_finalize
+  end select
+
+
+  return
+end subroutine PSE_ppsi

--- a/src/PSE_ppsi_DFT.f90
+++ b/src/PSE_ppsi_DFT.f90
@@ -1,0 +1,95 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_ppsi_DFT(ik)
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: ik
+  integer :: i,ix,iy,iz
+  real(8) :: kAc2_2
+  integer :: ilma,ia,j
+  complex(8) :: uVpsi
+
+  kAc2_2=sum(kAc_Cvec(:,ik)**2)*0.5
+
+  do i=1,NL
+    zft2(iLx(1,i),iLx(2,i),iLx(3,i))=tpsi(i)
+  end do
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(cexp_x3(:,iz)*zft2(ix,iy,:))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(cexp_x2(:,iy)*zft1(ix,:,iz))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(cexp_x1(:,ix)*zft2(:,iy,iz))
+  end do
+  end do
+  end do
+
+  zft1(:,:,:)=( &
+    -Epdir_1(1)*Grad_x_zI(:,:,:) &
+    -Epdir_1(2)*Grad_y_zI(:,:,:) &
+    -Epdir_1(3)*Grad_z_zI(:,:,:) &
+    )*zft1(:,:,:)/dble(NL1*NL2*NL3)
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(exp_x3(:,iz)*zft1(ix,iy,:))
+  end do
+  end do
+  end do
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft1(ix,iy,iz)=sum(exp_x2(:,iy)*zft2(ix,:,iz))
+  end do
+  end do
+  end do
+
+  do ix=0,NL1-1
+  do iy=0,NL2-1
+  do iz=0,NL3-1
+    zft2(ix,iy,iz)=sum(exp_x1(:,ix)*zft1(:,iy,iz))
+  end do
+  end do
+  end do
+
+  do i=1,NL
+    htpsi(i)=zft2(iLx(1,i),iLx(2,i),iLx(3,i))
+  end do
+
+  htpsi=htpsi+( & 
+    +Epdir_1(1)*kAc_Cvec(1,ik) &
+    +Epdir_1(2)*kAc_Cvec(2,ik) &
+    +Epdir_1(3)*kAc_Cvec(3,ik) &
+    )*tpsi
+  return
+
+  return
+end subroutine PSE_ppsi_DFT

--- a/src/PSE_preparation_basis_set.f90
+++ b/src/PSE_preparation_basis_set.f90
@@ -40,7 +40,7 @@ subroutine PSE_preparation_basis_set
   allocate(zu_basis(NL,NB_basis,NK_s:NK_e))
 
 
-  do iter_scf=1,100
+  do iter_scf=1,Nscf
     if(myrank == 0)write(*,*)kAc_Cvec(:,1)
     if(Myrank == 0)write(*,'(A,2X,I5)')'iter_scf = ',iter_scf
 

--- a/src/PSE_preparation_basis_set.f90
+++ b/src/PSE_preparation_basis_set.f90
@@ -99,7 +99,7 @@ subroutine PSE_preparation_basis_set
     end do
     NBs = NB_basis_main + NB_basis_shift*(ikshift-1) + 1
     NBe = NB_basis_main + NB_basis_shift*ikshift
-    zu_basis(:,NBs:NBe,NK_s:NK_e) = zu_GS(:,NBs:NBe,NK_s:NK_e)
+    zu_basis(:,NBs:NBe,NK_s:NK_e) = zu_GS(:,1:NB_basis_shift,NK_s:NK_e)
   end do
 
   do ik=NK_s,NK_e

--- a/src/PSE_preparation_basis_set.f90
+++ b/src/PSE_preparation_basis_set.f90
@@ -1,0 +1,123 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_preparation_basis_set
+  use global_variables
+  implicit none
+  integer :: iter_scf,ib
+  real(8) :: rmix=0.2d0
+  real(8) :: jav(3)
+  real(8) :: Etot,Ekin
+  real(8),allocatable :: Vloc_old(:)
+  character(10) :: cEex_Cor_tmp
+  integer :: NBs,NBe,ib1,ib2,ik,ikshift
+  real(8) :: ss
+  complex(8) :: zs
+
+  if(Myrank == 0)write(*,'(A)')'Preparation matrix-element start'
+  if(myrank == 0)write(*,*)'charge =',sum(rho_c)*H123,sum(rho_e)*H123,sum(rho_p)*H123  
+
+  NK_shift = 2
+  NB_basis_main = 14
+  NB_basis_shift = 14
+  NB_basis = NB_basis_main + NK_shift*NB_basis_shift
+  allocate(kshift(3,NK_shift))
+  kshift(1,1)=0.05d0/sqrt(2d0); kshift(2,1)=0.05d0/sqrt(2d0); kshift(3,1)=0d0
+  kshift(:,2)=-kshift(:,1)
+  if(NB < max(NB_basis_main,NB_basis_shift))stop "NB is too small."
+  allocate(zu_basis(NL,NB_basis,NK_s:NK_e))
+
+
+  do iter_scf=1,Nscf
+    if(myrank == 0)write(*,*)kAc_Cvec(:,1)
+    if(Myrank == 0)write(*,'(A,2X,I5)')'iter_scf = ',iter_scf
+
+    rho_MB_in(:,min(iter_scf,MaxMem_MB)) = rho_e(:) ! For Broiden's method
+    
+    call Gram_Schmidt
+    call PSE_Conjugate_Gradient(Ncg)
+    call Gram_Schmidt
+    call PSE_subspace_diag
+    call Gram_Schmidt
+
+
+    call PSE_current_GS(jav)
+    call PSE_energy(Etot,Ekin,'GS')
+    if(myrank == 0)write(*,'(A,e26.16e3)')'Etot =',Etot
+    if(myrank == 0)write(*,'(A,e26.16e3)')'Ekin =',Ekin
+    if(myrank == 0)write(*,'(3(A6,e16.6e3))')'jav(1)= ',jav(1),'jav(2)= ',jav(2),'jav(3)= ',jav(3)
+
+!    Vloc=Vxc ! debug
+    if(myrank == 0)write(*,*)'charge =',sum(rho_c)*H123,sum(rho_e)*H123,sum(rho_p)*H123
+    if(myrank == 0)write(*,*)sum(Vh**2)*H123
+
+    if(Myrank == 0)then
+      write(*,'(4(I3,e16.6e3))')(ib,esp(ib,NK_s),ib=1,NB)
+    end if
+  end do
+  zu_basis(:,1:NB_basis_main,NK_s:NK_e) = zu_GS(:,1:NB_basis_main,NK_s:NK_e)
+
+  do ikshift = 1,NK_shift
+    if(myrank == 0)write(*,"(A,2x,I7)")"ikshift =",ikshift
+    kAc_Cvec(1,:)=kAc0_Cvec(1,:)+kshift(1,ikshift)
+    kAc_Cvec(2,:)=kAc0_Cvec(2,:)+kshift(2,ikshift)
+    kAc_Cvec(3,:)=kAc0_Cvec(3,:)+kshift(3,ikshift)
+
+    do iter_scf=1,Nscf
+      if(myrank == 0)write(*,*)kAc_Cvec(:,1)
+      if(Myrank == 0)write(*,'(A,2X,I5)')'iter_scf = ',iter_scf
+
+      call Gram_Schmidt
+      call PSE_Conjugate_Gradient(Ncg)
+      call Gram_Schmidt
+      call PSE_subspace_diag
+      call Gram_Schmidt
+
+
+      call PSE_current_GS(jav)
+      call PSE_energy(Etot,Ekin,'GS')
+      if(myrank == 0)write(*,'(A,e26.16e3)')'Etot =',Etot
+      if(myrank == 0)write(*,'(A,e26.16e3)')'Ekin =',Ekin
+      if(myrank == 0)write(*,'(3(A6,e16.6e3))')'jav(1)= ',jav(1),'jav(2)= ',jav(2),'jav(3)= ',jav(3)
+
+!    Vloc=Vxc ! debug
+      if(myrank == 0)write(*,*)'charge =',sum(rho_c)*H123,sum(rho_e)*H123,sum(rho_p)*H123
+      if(myrank == 0)write(*,*)sum(Vh**2)*H123
+
+      if(Myrank == 0)then
+        write(*,'(4(I3,e16.6e3))')(ib,esp(ib,NK_s),ib=1,NB)
+      end if
+    end do
+    NBs = NB_basis_main + NB_basis_shift*(ikshift-1) + 1
+    NBe = NB_basis_main + NB_basis_shift*ikshift
+    zu_basis(:,NBs:NBe,NK_s:NK_e) = zu_GS(:,NBs:NBe,NK_s:NK_e)
+  end do
+
+  do ik=NK_s,NK_e
+    do ib1 = 1,NB_basis
+
+      do ib2 = 1,ib1-1
+        zs = sum(conjg(zu_basis(:,ib2,ik))*zu_basis(:,ib1,ik))*H123
+        zu_basis(:,ib1,ik) = zu_basis(:,ib1,ik) - zs*zu_basis(:,ib2,ik)
+      end do
+
+      ss = sum(abs(zu_basis(:,ib1,ik))**2)*H123
+      zu_basis(:,ib1,ik)=zu_basis(:,ib1,ik)/sqrt(ss)
+
+    end do
+  end do
+
+  return
+end subroutine PSE_preparation_basis_set

--- a/src/PSE_preparation_basis_set.f90
+++ b/src/PSE_preparation_basis_set.f90
@@ -30,8 +30,8 @@ subroutine PSE_preparation_basis_set
   if(myrank == 0)write(*,*)'charge =',sum(rho_c)*H123,sum(rho_e)*H123,sum(rho_p)*H123  
 
   NK_shift = 2
-  NB_basis_main = 14
-  NB_basis_shift = 14
+  NB_basis_main = 8
+  NB_basis_shift = 8
   NB_basis = NB_basis_main + NK_shift*NB_basis_shift
   allocate(kshift(3,NK_shift))
   kshift(1,1)=0.05d0/sqrt(2d0); kshift(2,1)=0.05d0/sqrt(2d0); kshift(3,1)=0d0
@@ -40,18 +40,15 @@ subroutine PSE_preparation_basis_set
   allocate(zu_basis(NL,NB_basis,NK_s:NK_e))
 
 
-  do iter_scf=1,Nscf
+  do iter_scf=1,100
     if(myrank == 0)write(*,*)kAc_Cvec(:,1)
     if(Myrank == 0)write(*,'(A,2X,I5)')'iter_scf = ',iter_scf
 
-    rho_MB_in(:,min(iter_scf,MaxMem_MB)) = rho_e(:) ! For Broiden's method
-    
     call Gram_Schmidt
     call PSE_Conjugate_Gradient(Ncg)
     call Gram_Schmidt
     call PSE_subspace_diag
     call Gram_Schmidt
-
 
     call PSE_current_GS(jav)
     call PSE_energy(Etot,Ekin,'GS')

--- a/src/PSE_preparation_matrix.f90
+++ b/src/PSE_preparation_matrix.f90
@@ -176,6 +176,7 @@ subroutine PSE_preparation_matrix
     open(200,file="basis_exp_basic.out",form='unformatted')
     write(200)NB_basis
     write(200)Amax,dAmax
+    write(200)Epdir_1
     close(200)
   end if
 

--- a/src/PSE_preparation_matrix.f90
+++ b/src/PSE_preparation_matrix.f90
@@ -44,7 +44,7 @@ subroutine PSE_preparation_matrix
   do ik=NK_s,NK_e
     do ib2=1,NB_basis
       tpsi(:)=zu_basis(:,ib2,ik)
-      call PSE_hpsi(ik)
+      call PSE_hpsi_loc(ik)
       do ib1=ib2,NB_basis
         zs=sum(conjg(zu_basis(:,ib1,ik))*htpsi(:))*H123
         zH_loc(ib1,ib2,ik)=zs

--- a/src/PSE_preparation_matrix.f90
+++ b/src/PSE_preparation_matrix.f90
@@ -1,0 +1,174 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_preparation_matrix
+  use global_variables
+  use PSE_variables
+  implicit none
+  real(8) :: f0_1,f0_2,omega_1,omega_2,tpulse_1,tpulse_2,T1_T2
+  integer :: ik,ib1,ib2,iav
+  complex(8) :: zs
+  integer :: ilma,ia,i,j,ix,iy,iz
+  complex(8) :: zjx1t,zjx2t,zjx3t,zjxt,zjyt,zjzt
+  complex(8) :: uVpsi,uVpsix,uVpsiy,uVpsiz
+  real(8) :: x1,x2,x3
+
+  f0_1=5.338d-9*sqrt(IWcm2_1)      ! electric field in a.u.
+  omega_1=omegaev_1/(2d0*Ry)  ! frequency in a.u.
+  Amax = f0_1/omega_1
+  dAmax = Amax/dble(NAmax)
+
+  allocate(zH_loc(NB_basis,NB_basis,NK_s:NK_e))
+  allocate(zPi_loc(NB_basis,NB_basis,NK_s:NK_e))
+  allocate(zV_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
+  allocate(zPi_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
+
+  kAc_Cvec(:,:)=kAc0_Cvec(:,:)
+  call PSE_pre_hpsi
+! compute zH_loc
+  zH_loc = 0d0
+  do ik=NK_s,NK_e
+    do ib2=1,NB_basis
+      tpsi(:)=zu_basis(:,ib2,ik)
+      call PSE_hpsi(ik)
+      do ib1=ib2,NB_basis
+        zs=sum(conjg(zu_basis(:,ib1,ik))*htpsi(:))*H123
+        zH_loc(ib1,ib2,ik)=zs
+        zH_loc(ib2,ib1,ik)=conjg(zs)
+        if(ib1 == ib2) zH_loc(ib1,ib2,ik)=real(zs)
+      end do
+    end do
+  end do
+
+! compute zPi_loc
+  zPi_loc = 0d0
+  do ik=NK_s,NK_e
+    do ib2=1,NB_basis
+      tpsi(:)=zu_basis(:,ib2,ik)
+      call PSE_ppsi(ik)
+      do ib1=ib2,NB_basis
+        zs=sum(conjg(zu_basis(:,ib1,ik))*htpsi(:))*H123
+        zPi_loc(ib1,ib2,ik)=zs
+        zPi_loc(ib2,ib1,ik)=conjg(zs)
+        if(ib1 == ib2) zPi_loc(ib1,ib2,ik)=real(zs)
+      end do
+    end do
+  end do
+
+! compute zV_NL
+  do iav = -NAmax,NAmax
+    kAc_Cvec(1,:)=kAc0_Cvec(1,:) + dAmax*dble(iav)*Epdir_1(1)
+    kAc_Cvec(2,:)=kAc0_Cvec(2,:) + dAmax*dble(iav)*Epdir_1(2)
+    kAc_Cvec(3,:)=kAc0_Cvec(3,:) + dAmax*dble(iav)*Epdir_1(3)
+    call PSE_pre_hpsi
+    do ik=NK_s,NK_e
+      do ib2=1,NB_basis
+        tpsi(:)=zu_basis(:,ib2,ik)
+        call PSE_Vnlpsi(ik)
+        do ib1=ib2,NB_basis
+          zs=sum(conjg(zu_basis(:,ib1,ik))*htpsi(:))*H123
+          zV_NL(ib1,ib2,ik,iav)=zs
+          zV_NL(ib2,ib1,ik,iav)=conjg(zs)
+          if(ib1 == ib2) zV_NL(ib1,ib2,ik,iav)=real(zs)
+        end do
+      end do
+    end do
+  end do
+
+
+! compute zPi_NL
+  do iav = -NAmax,NAmax
+    kAc_Cvec(1,:)=kAc0_Cvec(1,:) + dAmax*dble(iav)*Epdir_1(1)
+    kAc_Cvec(2,:)=kAc0_Cvec(2,:) + dAmax*dble(iav)*Epdir_1(2)
+    kAc_Cvec(3,:)=kAc0_Cvec(3,:) + dAmax*dble(iav)*Epdir_1(3)
+    call PSE_pre_hpsi
+
+    do ik=NK_s,NK_e
+      do ib2=1,NB_basis
+        do ib1=ib2,NB_basis
+! <b1| r*VNL | b2>
+          zjx1t=0d0;zjx2t=0d0;zjx3t=0d0
+          do ilma=1,Nlma
+            ia=a_tbl(ilma)
+            uVpsi=0.d0; uVpsix=0.d0; uVpsiy=0.d0; uVpsiz=0.d0
+            do j=1,Mps(ia)
+              i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
+              x1=Lx(1,i)-dble(Jxx(j,ia))
+              x2=Lx(2,i)-dble(Jyy(j,ia))
+              x3=Lx(3,i)-dble(Jzz(j,ia))
+
+              uVpsi =uVpsi +uV(j,ilma)*ekr(j,ia,ik)  *zu_basis(i,ib2,ik)
+              uVpsix=uVpsix+uV(j,ilma)*ekr(j,ia,ik)*x1*zu_basis(i,ib1,ik)
+              uVpsiy=uVpsiy+uV(j,ilma)*ekr(j,ia,ik)*x2*zu_basis(i,ib1,ik)
+              uVpsiz=uVpsiz+uV(j,ilma)*ekr(j,ia,ik)*x3*zu_basis(i,ib1,ik)
+            end do
+            uVpsi =uVpsi *H123*iuV(ilma)
+            uVpsix=uVpsix*H123
+            uVpsiy=uVpsiy*H123
+            uVpsiz=uVpsiz*H123
+            
+            zjx1t=zjx1t+conjg(uVpsix)*uVpsi/zI
+            zjx2t=zjx2t+conjg(uVpsiy)*uVpsi/zI
+            zjx3t=zjx3t+conjg(uVpsiz)*uVpsi/zI
+          enddo
+
+          zjxt=A_matrix(1,1)*zjx1t+A_matrix(1,2)*zjx2t+A_matrix(1,3)*zjx3t
+          zjyt=A_matrix(2,1)*zjx1t+A_matrix(2,2)*zjx2t+A_matrix(2,3)*zjx3t
+          zjzt=A_matrix(3,1)*zjx1t+A_matrix(3,2)*zjx2t+A_matrix(3,3)*zjx3t
+
+          zs = Epdir_1(1)*zjxt + Epdir_1(2)*zjyt+ Epdir_1(3)*zjzt
+
+! <b1| VNL*r | b2>
+          zjx1t=0d0;zjx2t=0d0;zjx3t=0d0
+          do ilma=1,Nlma
+            ia=a_tbl(ilma)
+            uVpsi=0.d0; uVpsix=0.d0; uVpsiy=0.d0; uVpsiz=0.d0
+            do j=1,Mps(ia)
+              i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
+              x1=Lx(1,i)-dble(Jxx(j,ia))
+              x2=Lx(2,i)-dble(Jyy(j,ia))
+              x3=Lx(3,i)-dble(Jzz(j,ia))
+
+              uVpsi =uVpsi +uV(j,ilma)*ekr(j,ia,ik)  *zu_basis(i,ib1,ik)
+              uVpsix=uVpsix+uV(j,ilma)*ekr(j,ia,ik)*x1*zu_basis(i,ib2,ik)
+              uVpsiy=uVpsiy+uV(j,ilma)*ekr(j,ia,ik)*x2*zu_basis(i,ib2,ik)
+              uVpsiz=uVpsiz+uV(j,ilma)*ekr(j,ia,ik)*x3*zu_basis(i,ib2,ik)
+            end do
+            uVpsi =uVpsi *H123*iuV(ilma)
+            uVpsix=uVpsix*H123
+            uVpsiy=uVpsiy*H123
+            uVpsiz=uVpsiz*H123
+            
+            zjx1t=zjx1t+conjg(uVpsi)*uVpsix/zI
+            zjx2t=zjx2t+conjg(uVpsi)*uVpsiy/zI
+            zjx3t=zjx3t+conjg(uVpsi)*uVpsiz/zI
+          enddo
+
+          zjxt=A_matrix(1,1)*zjx1t+A_matrix(1,2)*zjx2t+A_matrix(1,3)*zjx3t
+          zjyt=A_matrix(2,1)*zjx1t+A_matrix(2,2)*zjx2t+A_matrix(2,3)*zjx3t
+          zjzt=A_matrix(3,1)*zjx1t+A_matrix(3,2)*zjx2t+A_matrix(3,3)*zjx3t
+
+          zs = zs - (Epdir_1(1)*zjxt + Epdir_1(2)*zjyt+ Epdir_1(3)*zjzt)
+          zPi_NL(ib1,ib2,ik,iav)=zs
+          zPi_NL(ib2,ib1,ik,iav)=conjg(zs)
+          if(ib1 == ib2) zPi_NL(ib1,ib2,ik,iav)=real(zs)
+
+        end do
+      end do
+    end do
+  end do
+
+  return
+end subroutine PSE_preparation_matrix

--- a/src/PSE_preparation_matrix.f90
+++ b/src/PSE_preparation_matrix.f90
@@ -24,6 +24,8 @@ subroutine PSE_preparation_matrix
   complex(8) :: zjx1t,zjx2t,zjx3t,zjxt,zjyt,zjzt
   complex(8) :: uVpsi,uVpsix,uVpsiy,uVpsiz
   real(8) :: x1,x2,x3
+  character(50) :: cik, filename
+
 
   f0_1=5.338d-9*sqrt(IWcm2_1)      ! electric field in a.u.
   omega_1=omegaev_1/(2d0*Ry)  ! frequency in a.u.
@@ -169,6 +171,25 @@ subroutine PSE_preparation_matrix
       end do
     end do
   end do
+
+  if(myrank == 0)then
+    open(200,file="basis_exp_basic.out",form='unformatted')
+    write(200)NB_basis
+    write(200)Amax,dAmax
+    close(200)
+  end if
+
+  do ik = NK_s,NK_e
+    write(cik,"(I9.9)")ik
+    filename=trim(cik)//"_matrix_elements.out"
+    open(201,file=filename,form='unformatted')
+    write(201)zH_loc
+    write(201)zPi_loc
+    write(201)zV_NL
+    write(201)zPi_NL
+    close(201)
+  end do
+
 
   return
 end subroutine PSE_preparation_matrix

--- a/src/PSE_preparation_matrix.f90
+++ b/src/PSE_preparation_matrix.f90
@@ -184,10 +184,10 @@ subroutine PSE_preparation_matrix
     write(cik,"(I9.9)")ik
     filename=trim(cik)//"_matrix_elements.out"
     open(201,file=filename,form='unformatted')
-    write(201)zH_loc
-    write(201)zPi_loc
-    write(201)zV_NL
-    write(201)zPi_NL
+    write(201)zH_loc(:,:,ik)
+    write(201)zPi_loc(:,:,ik)
+    write(201)zV_NL(:,:,ik,:)
+    write(201)zPi_NL(:,:,ik,:)
     close(201)
   end do
 

--- a/src/PSE_read_matrix_elements.f90
+++ b/src/PSE_read_matrix_elements.f90
@@ -49,10 +49,10 @@ subroutine PSE_read_matrix_elements
     write(cik,"(I9.9)")ik
     filename=trim(cik)//"_matrix_elements.out"
     open(201,file=filename,form='unformatted')
-    read(201)zH_loc
-    read(201)zPi_loc
-    read(201)zV_NL
-    read(201)zPi_NL
+    read(201)zH_loc(:,:,ik)
+    read(201)zPi_loc(:,:,ik)
+    read(201)zV_NL(:,:,ik,:)
+    read(201)zPi_NL(:,:,ik,:)
     close(201)
   end do
 

--- a/src/PSE_read_matrix_elements.f90
+++ b/src/PSE_read_matrix_elements.f90
@@ -42,6 +42,8 @@ subroutine PSE_read_matrix_elements
   allocate(zPi_loc(NB_basis,NB_basis,NK_s:NK_e))
   allocate(zV_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
   allocate(zPi_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
+  allocate(zH_tot(NB_basis,NB_basis,NK_s:NK_e))
+  allocate(zPi_tot(NB_basis,NB_basis,NK_s:NK_e))
 
   do ik = NK_s,NK_e
     write(cik,"(I9.9)")ik

--- a/src/PSE_read_matrix_elements.f90
+++ b/src/PSE_read_matrix_elements.f90
@@ -1,0 +1,59 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_read_matrix_elements
+  use global_variables
+  implicit none
+  integer :: ik
+  character(50) :: cik, filename
+
+
+  if(myrank == 0)then
+    open(200,file="basis_exp_basic.out",form='unformatted')
+    read(200)NB_basis
+    read(200)Amax,dAmax
+    read(200)Epdir_1
+    close(200)
+  end if
+
+  call MPI_BCAST(NB_basis,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(Amax,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(dAmax,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(Epdir_1,3,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+
+  if(abs(dble(NAmax) -Amax/dAmax) > 0.01d0)then
+    err_message='NAmax is not consistent.'
+    call err_finalize
+  end if
+
+  allocate(zH_loc(NB_basis,NB_basis,NK_s:NK_e))
+  allocate(zPi_loc(NB_basis,NB_basis,NK_s:NK_e))
+  allocate(zV_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
+  allocate(zPi_NL(NB_basis,NB_basis,NK_s:NK_e,-NAmax:NAmax))
+
+  do ik = NK_s,NK_e
+    write(cik,"(I9.9)")ik
+    filename=trim(cik)//"_matrix_elements.out"
+    open(201,file=filename,form='unformatted')
+    read(201)zH_loc
+    read(201)zPi_loc
+    read(201)zV_NL
+    read(201)zPi_NL
+    close(201)
+  end do
+
+
+  return
+end subroutine PSE_read_matrix_elements

--- a/src/PSE_read_matrix_elements.f90
+++ b/src/PSE_read_matrix_elements.f90
@@ -19,7 +19,7 @@ subroutine PSE_read_matrix_elements
   integer :: ik
   character(50) :: cik, filename
 
-
+  if(myrank == 0)write(*,"(A)")"== Start reading matrix elements."
   if(myrank == 0)then
     open(200,file="basis_exp_basic.out",form='unformatted')
     read(200)NB_basis
@@ -56,6 +56,6 @@ subroutine PSE_read_matrix_elements
     close(201)
   end do
 
-
+  if(myrank == 0)write(*,"(A)")"== End reading matrix elements."
   return
 end subroutine PSE_read_matrix_elements

--- a/src/PSE_real_time_propagation.f90
+++ b/src/PSE_real_time_propagation.f90
@@ -38,7 +38,8 @@ subroutine PSE_real_time_propagation
   kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Actot_Cvec(1,0)
   kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Actot_Cvec(2,0)
   kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Actot_Cvec(3,0)
-  call PSE_current_RT(jav)
+!  call PSE_current_RT(jav)
+  call PSE_current_RT_DFT(jav)
   javt_Cvec(:,0)=jav(:)
 !== End current
 
@@ -51,14 +52,25 @@ subroutine PSE_real_time_propagation
 
   do iter=0,Nt
 
-    call PSE_dt_evolve(iter)
+    select case(option_IP)
+    case('N')
+      call PSE_dt_evolve(iter)
+    case('Y')
+      call PSE_dt_evolve_IP(iter)
+    case default
+      err_message='invalid option_IP'
+      call err_finalize
+    end select
+
 
 !== Start current
     kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Actot_Cvec(1,iter+1)
     kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Actot_Cvec(2,iter+1)
     kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Actot_Cvec(3,iter+1)
 
-    call PSE_current_RT(jav)
+!  call PSE_current_RT(jav)
+    call PSE_current_RT_DFT(jav)
+
     javt_Cvec(:,iter+1)=jav(:)
 !== End current
 

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -1,0 +1,26 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine PSE_real_time_propagation_basis_expansion
+  use global_variables
+  use PSE_variables
+  implicit none
+  integer :: iter,iter_t
+  real(8) :: jav
+
+  call init_Ac_basis_expansion
+
+  return
+end subroutine PSE_real_time_propagation_basis_expansion

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -19,6 +19,8 @@ subroutine PSE_real_time_propagation_basis_expansion
   integer :: iter,iter_t
   real(8) :: jav,Act_t
 
+  if(myrank == 0)write(*,"(A)")"== Start real-time propagation with basis expansion."
+
   call init_wf_basis_expansion
   call init_Ac_basis_expansion
 
@@ -41,6 +43,8 @@ subroutine PSE_real_time_propagation_basis_expansion
 !== End current
 
   end do
+
+  if(myrank == 0)write(*,"(A)")"== End real-time propagation with basis expansion."
 
   return
 end subroutine PSE_real_time_propagation_basis_expansion

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -17,10 +17,39 @@ subroutine PSE_real_time_propagation_basis_expansion
   use global_variables
   implicit none
   integer :: iter,iter_t
-  real(8) :: jav
+  real(8) :: jav,Act_t
 
   call init_wf_basis_expansion
   call init_Ac_basis_expansion
+
+!== Start current
+  Act_t = Actot_BE(0)
+  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
+  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
+  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
+!  call BE_current(jav)
+  javt_BE(0)=jav
+!== End current
+
+  do iter=0,Nt
+!== Start dt_evolve
+    Act_t = 0.5d0*( Actot_BE(iter+1) + Actot_BE(iter) )
+    kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
+    kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
+    kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
+!  call BE_dt_evolve
+!== End dt_evolve
+
+!== Start current
+  Act_t = Actot_BE(iter+1)
+  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
+  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
+  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
+!  call BE_current(jav)
+  javt_BE(iter+1)=jav
+!== End current
+
+  end do
 
   return
 end subroutine PSE_real_time_propagation_basis_expansion

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -26,7 +26,7 @@ subroutine PSE_real_time_propagation_basis_expansion
 
 !== Start current
   Act_t = Actot_BE(0)
-  call BE_current(jav)
+  call BE_current(jav,Act_t)
   javt_BE(0)=jav
 !== End current
 
@@ -38,7 +38,7 @@ subroutine PSE_real_time_propagation_basis_expansion
 
 !== Start current
   Act_t = Actot_BE(iter+1)
-  call BE_current(jav)
+  call BE_current(jav,Act_t)
   javt_BE(iter+1)=jav
 !== End current
 

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -42,6 +42,18 @@ subroutine PSE_real_time_propagation_basis_expansion
   javt_BE(iter+1)=jav
 !== End current
 
+!== Start writing section
+  if(mod(iter,400) == 0 .or. iter == Nt)then
+    if(myrank == 0)then
+      open(102,file=trim(SYSname)//'_jac.out')
+      do iter_t=0,Nt+1
+        write(102,'(100e26.16e3)')Dt*dble(iter_t),Actot_BE(iter_t),javt_BE(iter_t)
+      end do
+      close(102)
+    end if
+  end if
+!== End writing section
+
   end do
 
   if(myrank == 0)write(*,"(A)")"== End real-time propagation with basis expansion."

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -24,10 +24,7 @@ subroutine PSE_real_time_propagation_basis_expansion
 
 !== Start current
   Act_t = Actot_BE(0)
-  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
-  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
-  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
-!  call BE_current(jav)
+  call BE_current(jav)
   javt_BE(0)=jav
 !== End current
 
@@ -42,10 +39,7 @@ subroutine PSE_real_time_propagation_basis_expansion
 
 !== Start current
   Act_t = Actot_BE(iter+1)
-  kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
-  kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
-  kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
-!  call BE_current(jav)
+  call BE_current(jav)
   javt_BE(iter+1)=jav
 !== End current
 

--- a/src/PSE_real_time_propagation_basis_expansion.f90
+++ b/src/PSE_real_time_propagation_basis_expansion.f90
@@ -31,10 +31,7 @@ subroutine PSE_real_time_propagation_basis_expansion
   do iter=0,Nt
 !== Start dt_evolve
     Act_t = 0.5d0*( Actot_BE(iter+1) + Actot_BE(iter) )
-    kAc_Cvec(1,:)=kAc0_Cvec(1,:)+Act_t*Epdir_1(1)
-    kAc_Cvec(2,:)=kAc0_Cvec(2,:)+Act_t*Epdir_1(2)
-    kAc_Cvec(3,:)=kAc0_Cvec(3,:)+Act_t*Epdir_1(3)
-!  call BE_dt_evolve
+    call BE_dt_evolve(Act_t)
 !== End dt_evolve
 
 !== Start current

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -144,11 +144,12 @@ module global_variables
   complex(8),allocatable :: zu_basis(:,:,:)
   complex(8),allocatable :: zH_loc(:,:,:),zPi_loc(:,:,:)
   complex(8),allocatable :: zV_NL(:,:,:,:),zPi_NL(:,:,:,:)
+  complex(8),allocatable :: zH_tot(:,:,:),zPi_tot(:,:,:)
   integer,parameter :: NAmax = 10
   real(8) :: Amax,dAmax
   real(8),allocatable :: Actot_BE(:),javt_BE(:)
 
-  complex(8),allocatable :: zCt(:,:,:)
+  complex(8),allocatable :: zCt(:,:,:),zACt_tmp(:)
 
 end Module Global_Variables
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -146,7 +146,7 @@ module global_variables
   complex(8),allocatable :: zV_NL(:,:,:,:),zPi_NL(:,:,:,:)
   integer,parameter :: NAmax = 10
   real(8) :: Amax,dAmax
-  real(8),allocatable :: Actot_BE(:)
+  real(8),allocatable :: Actot_BE(:),javt_BE(:)
 
   complex(8),allocatable :: zCt(:,:,:)
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -149,7 +149,7 @@ module global_variables
   real(8) :: Amax,dAmax
   real(8),allocatable :: Actot_BE(:),javt_BE(:)
 
-  complex(8),allocatable :: zCt(:,:,:),zACt_tmp(:)
+  complex(8),allocatable :: zCt(:,:,:),zACt_tmp(:),ztCt_tmp(:)
 
 end Module Global_Variables
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -146,6 +146,7 @@ module global_variables
   complex(8),allocatable :: zV_NL(:,:,:,:),zPi_NL(:,:,:,:)
   integer,parameter :: NAmax = 10
   real(8) :: Amax,dAmax
+  real(8),allocatable :: Actot_BE(:)
 
 end Module Global_Variables
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -142,6 +142,10 @@ module global_variables
   integer :: NB_basis, NK_shift, NB_basis_main,NB_basis_shift
   real(8),allocatable :: kshift(:,:)
   complex(8),allocatable :: zu_basis(:,:,:)
+  complex(8),allocatable :: zH_loc(:,:,:),zPi_loc(:,:,:)
+  complex(8),allocatable :: zV_NL(:,:,:,:),zPi_NL(:,:,:,:)
+  integer,parameter :: NAmax = 10
+  real(8) :: Amax,dAmax
 
 end Module Global_Variables
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -90,6 +90,7 @@ module global_variables
   integer :: Ncg,Nscf
 
 ! RT parameter
+  character(1) :: option_IP='N'
   integer :: Nt
   real(8) :: dt
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -148,6 +148,8 @@ module global_variables
   real(8) :: Amax,dAmax
   real(8),allocatable :: Actot_BE(:)
 
+  complex(8),allocatable :: zCt(:,:,:)
+
 end Module Global_Variables
 
 

--- a/src/global_variables.f90
+++ b/src/global_variables.f90
@@ -138,6 +138,11 @@ module global_variables
   real(8),parameter :: alpha_MB = 0.35d0
   real(8),allocatable :: rho_MB_in(:,:),rho_MB_out(:,:)
 
+! Basis expansion method
+  integer :: NB_basis, NK_shift, NB_basis_main,NB_basis_shift
+  real(8),allocatable :: kshift(:,:)
+  complex(8),allocatable :: zu_basis(:,:,:)
+
 end Module Global_Variables
 
 

--- a/src/init_Ac_basis_expansion.f90
+++ b/src/init_Ac_basis_expansion.f90
@@ -20,7 +20,7 @@ subroutine init_Ac_basis_expansion
   real(8) :: tt
   real(8) :: f0_1,f0_2,omega_1,omega_2,tpulse_1,tpulse_2,T1_T2
 
-  if(myrank == 0)write(*,"(A)")"== Initialization of vector potential."
+  if(myrank == 0)write(*,"(A)")"== Start: Initialization of vector potential."
 
   allocate(Actot_BE(0:Nt+2),javt_BE(0:Nt+1))
 
@@ -31,11 +31,10 @@ subroutine init_Ac_basis_expansion
   omega_2=omegaev_2/(2d0*Ry)  ! frequency in a.u.
   tpulse_2=tpulsefs_2/0.02418d0 ! pulse duration in a.u.
   T1_T2=T1_T2fs/0.02418d0 ! pulse duration in a.u.
-  javt_Cvec=0.d0
+  javt_BE=0.d0
   Actot_BE = 0d0 
 
 ! 'cos2cos'                          ! laser_type 'cos2cos', 'cos4cos' or 'impulse'
-
   select case(laser_type)
   case('impulse')
     Actot_BE = dAc
@@ -77,6 +76,8 @@ subroutine init_Ac_basis_expansion
     err_message='error in init_Ac'
     call err_finalize
   end select
+
+  if(myrank == 0)write(*,"(A)")"== End: Initialization of vector potential."
 
   return
 end subroutine init_Ac_basis_expansion

--- a/src/init_Ac_basis_expansion.f90
+++ b/src/init_Ac_basis_expansion.f90
@@ -20,6 +20,8 @@ subroutine init_Ac_basis_expansion
   real(8) :: tt
   real(8) :: f0_1,f0_2,omega_1,omega_2,tpulse_1,tpulse_2,T1_T2
 
+  if(myrank == 0)write(*,"(A)")"== Initialization of vector potential."
+
   allocate(Actot_BE(0:Nt+2),javt_BE(0:Nt+1))
 
   f0_1=5.338d-9*sqrt(IWcm2_1)      ! electric field in a.u.

--- a/src/init_Ac_basis_expansion.f90
+++ b/src/init_Ac_basis_expansion.f90
@@ -20,7 +20,7 @@ subroutine init_Ac_basis_expansion
   real(8) :: tt
   real(8) :: f0_1,f0_2,omega_1,omega_2,tpulse_1,tpulse_2,T1_T2
 
-  allocate(Actot_BE(0:Nt+2))
+  allocate(Actot_BE(0:Nt+2),javt_BE(0:Nt+1))
 
   f0_1=5.338d-9*sqrt(IWcm2_1)      ! electric field in a.u.
   omega_1=omegaev_1/(2d0*Ry)  ! frequency in a.u.

--- a/src/init_Ac_basis_expansion.f90
+++ b/src/init_Ac_basis_expansion.f90
@@ -1,0 +1,80 @@
+!
+!  Copyright 2016 ARTED developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine init_Ac_basis_expansion
+  use global_variables
+  implicit none
+  integer :: iter
+  real(8) :: tt
+  real(8) :: f0_1,f0_2,omega_1,omega_2,tpulse_1,tpulse_2,T1_T2
+
+  allocate(Actot_BE(0:Nt+2))
+
+  f0_1=5.338d-9*sqrt(IWcm2_1)      ! electric field in a.u.
+  omega_1=omegaev_1/(2d0*Ry)  ! frequency in a.u.
+  tpulse_1=tpulsefs_1/0.02418d0 ! pulse duration in a.u.
+  f0_2=5.338d-9*sqrt(IWcm2_2)      ! electric field in a.u.
+  omega_2=omegaev_2/(2d0*Ry)  ! frequency in a.u.
+  tpulse_2=tpulsefs_2/0.02418d0 ! pulse duration in a.u.
+  T1_T2=T1_T2fs/0.02418d0 ! pulse duration in a.u.
+  javt_Cvec=0.d0
+  Actot_BE = 0d0 
+
+! 'cos2cos'                          ! laser_type 'cos2cos', 'cos4cos' or 'impulse'
+
+  select case(laser_type)
+  case('impulse')
+    Actot_BE = dAc
+  case('cos2cos')
+! pulse shape : A(t)=f0/omega*sin(Pi t/T)**2 *cos (omega t+phi_CEP*2d0*pi) 
+! pump laser
+    do iter=0,Nt+2
+      tt=iter*dt
+      if (tt<tpulse_1) then
+        Actot_BE(iter)=-f0_1/omega_1*(sin(pi*tt/tpulse_1))**2*cos(omega_1*tt+phi_CEP_1*2d0*pi)
+      end if
+    enddo
+! probe laser
+    do iter=0,Nt+2
+      tt=iter*dt
+      if ( (tt-T1_T2>0d0) .and. (tt-T1_T2<tpulse_2) ) then
+        Actot_BE(iter)=Actot_BE(iter) &
+          &-f0_2/omega_2*(sin(pi*(tt-T1_T2)/tpulse_2))**2*cos(omega_2*(tt-T1_T2)+phi_CEP_2*2d0*pi)
+      endif
+    enddo
+  case('cos4cos')
+! pulse shape : A(t)=f0/omega*sin(Pi t/T)**2 *cos (omega t+phi_CEP*2d0*pi) 
+! pump laser
+    do iter=0,Nt+2
+      tt=iter*dt
+      if (tt<tpulse_1) then
+        Actot_BE(iter)=-f0_1/omega_1*(cos(pi*(tt-0.5d0*tpulse_1)/tpulse_1))**4*sin(omega_1*(tt-0.5d0*tpulse_1)+phi_CEP_1*2d0*pi)
+      end if
+    enddo
+! probe laser
+    do iter=0,Nt+2
+      tt=iter*dt
+      if ( (tt>0.5d0*(tpulse_1-tpulse_2)+T1_T2) .and. (tt>0.5d0*(tpulse_1-tpulse_2)+T1_T2+tpulse_2) ) then
+        Actot_BE(iter)=Actot_BE(iter) &
+          &-f0_2/omega_2*(cos(pi*(tt-(0.5d0*tpulse_1+T1_T2))/tpulse_2))**4*sin(omega_2*(tt-(0.5d0*tpulse_1+T1_T2))+phi_CEP_2*2d0*pi)
+      endif
+    enddo
+  case default
+    err_message='error in init_Ac'
+    call err_finalize
+  end select
+
+  return
+end subroutine init_Ac_basis_expansion

--- a/src/init_wf_basis_expansion.f90
+++ b/src/init_wf_basis_expansion.f90
@@ -24,7 +24,7 @@ subroutine init_wf_basis_expansion
   real(8),allocatable :: rwork(:),w(:)
   integer :: info
 
-  if(myrank == 0)write(*,"(A)")"== Initialization of wavefunctions."
+  if(myrank == 0)write(*,"(A)")"== Start: Initialization of wavefunctions."
 
   lwork=6*NB_basis
   allocate(work_lp(lwork),rwork(3*NB_basis-2),w(NB_basis))
@@ -37,6 +37,8 @@ subroutine init_wf_basis_expansion
     call zheev('V', 'U', NB_basis, zMat_diag, NB_basis, w, work_lp, lwork, rwork, info)
     zCt(1:NB_basis,1:NB_TD,ik)=zMat_diag(1:NB_basis,1:NB_TD)
   end do
+
+  if(myrank == 0)write(*,"(A)")"== End: Initialization of wavefunctions."
 
   return
 end subroutine init_wf_basis_expansion

--- a/src/init_wf_basis_expansion.f90
+++ b/src/init_wf_basis_expansion.f90
@@ -28,7 +28,7 @@ subroutine init_wf_basis_expansion
   allocate(work_lp(lwork),rwork(3*NB_basis-2),w(NB_basis))
   allocate(zMat_diag(NB_basis,NB_basis))
 
-  allocate(zCt(NB_basis,NB_TD,NK_s:NK_e),zACt_tmp(NB_basis))
+  allocate(zCt(NB_basis,NB_TD,NK_s:NK_e),ztCt_tmp(NB_basis),zACt_tmp(NB_basis))
 
   do ik = NK_s,NK_e
     zMat_diag(:,:)=zH_loc(:,:,ik)+zV_NL(:,:,ik,0)

--- a/src/init_wf_basis_expansion.f90
+++ b/src/init_wf_basis_expansion.f90
@@ -24,6 +24,8 @@ subroutine init_wf_basis_expansion
   real(8),allocatable :: rwork(:),w(:)
   integer :: info
 
+  if(myrank == 0)write(*,"(A)")"== Initialization of wavefunctions."
+
   lwork=6*NB_basis
   allocate(work_lp(lwork),rwork(3*NB_basis-2),w(NB_basis))
   allocate(zMat_diag(NB_basis,NB_basis))
@@ -33,7 +35,7 @@ subroutine init_wf_basis_expansion
   do ik = NK_s,NK_e
     zMat_diag(:,:)=zH_loc(:,:,ik)+zV_NL(:,:,ik,0)
     call zheev('V', 'U', NB_basis, zMat_diag, NB_basis, w, work_lp, lwork, rwork, info)
-    zCt(1:NB_basis,1:NB_TD,ik)=zMat_diag(1:NB_basis,1:NB)
+    zCt(1:NB_basis,1:NB_TD,ik)=zMat_diag(1:NB_basis,1:NB_TD)
   end do
 
   return

--- a/src/init_wf_basis_expansion.f90
+++ b/src/init_wf_basis_expansion.f90
@@ -13,14 +13,28 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine PSE_real_time_propagation_basis_expansion
+subroutine init_wf_basis_expansion
   use global_variables
   implicit none
-  integer :: iter,iter_t
-  real(8) :: jav
+  complex(8),allocatable :: zMat_diag(:,:)
+  integer :: ik
+!LAPACK
+  integer :: lwork
+  complex(8),allocatable :: work_lp(:)
+  real(8),allocatable :: rwork(:),w(:)
+  integer :: info
 
-  call init_wf_basis_expansion
-  call init_Ac_basis_expansion
+  lwork=6*NB_basis
+  allocate(work_lp(lwork),rwork(3*NB_basis-2),w(NB_basis))
+  allocate(zMat_diag(NB_basis,NB_basis))
+
+  allocate(zCt(NB_basis,NB_TD,NK_s:NK_e))
+
+  do ik = NK_s,NK_e
+    zMat_diag(:,:)=zH_loc(:,:,ik)+zV_NL(:,:,ik,0)
+    call zheev('V', 'U', NB_basis, zMat_diag, NB_basis, w, work_lp, lwork, rwork, info)
+    zCt(1:NB_basis,1:NB_TD,ik)=zMat_diag(1:NB_basis,1:NB)
+  end do
 
   return
-end subroutine PSE_real_time_propagation_basis_expansion
+end subroutine init_wf_basis_expansion

--- a/src/init_wf_basis_expansion.f90
+++ b/src/init_wf_basis_expansion.f90
@@ -28,7 +28,7 @@ subroutine init_wf_basis_expansion
   allocate(work_lp(lwork),rwork(3*NB_basis-2),w(NB_basis))
   allocate(zMat_diag(NB_basis,NB_basis))
 
-  allocate(zCt(NB_basis,NB_TD,NK_s:NK_e))
+  allocate(zCt(NB_basis,NB_TD,NK_s:NK_e),zACt_tmp(NB_basis))
 
   do ik = NK_s,NK_e
     zMat_diag(:,:)=zH_loc(:,:,ik)+zV_NL(:,:,ik,0)

--- a/src/main.f90
+++ b/src/main.f90
@@ -49,7 +49,10 @@ program main
     call PSE_preparation_basis_set
     call PSE_preparation_matrix
 
-  case('MT') ! prepare matrix elements
+  case('MT') ! Time-propagation with basis expansion
+
+    call PSE_read_matrix_elements
+
   case default
     err_message='invalid calc_mode'
     call err_finalize

--- a/src/main.f90
+++ b/src/main.f90
@@ -45,7 +45,7 @@ program main
       read(99)Vloc
       close(99)
     end if
-    call MPI_BCAST(Vloc,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+    call MPI_BCAST(Vloc,NL,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
     call PSE_preparation_basis_set
     call PSE_preparation_matrix
 

--- a/src/main.f90
+++ b/src/main.f90
@@ -52,7 +52,7 @@ program main
   case('MT') ! Time-propagation with basis expansion
 
     call PSE_read_matrix_elements
-
+    call PSE_real_time_propagation_basis_expansion
   case default
     err_message='invalid calc_mode'
     call err_finalize

--- a/src/main.f90
+++ b/src/main.f90
@@ -47,6 +47,7 @@ program main
     end if
     call MPI_BCAST(Vloc,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
     call PSE_preparation_basis_set
+    call PSE_preparation_matrix
 
   case('MT') ! prepare matrix elements
   case default

--- a/src/main.f90
+++ b/src/main.f90
@@ -24,15 +24,21 @@ program main
   implicit none
 
   call preparation
-  write(*,*)myrank,NK_s
-  call PSE_ground_state_calculation
 
   select case(calc_mode)
   case('RT')
+    call PSE_ground_state_calculation
     call PSE_real_time_propagation
   case('BD')
-      call PSE_band_calculation
+    call PSE_ground_state_calculation
+    call PSE_band_calculation
   case('GS')
+    call PSE_ground_state_calculation
+    if(myrank == 0)then
+      open(99,file="Vloc_gs.out",form='unformatted')
+      write(99)Vloc
+      close(99)
+    end if
   case default
     err_message='invalid calc_mode'
     call err_finalize

--- a/src/main.f90
+++ b/src/main.f90
@@ -26,19 +26,29 @@ program main
   call preparation
 
   select case(calc_mode)
-  case('RT')
+  case('RT') ! real-time propagation
     call PSE_ground_state_calculation
     call PSE_real_time_propagation
-  case('BD')
+  case('BD') ! band structure
     call PSE_ground_state_calculation
     call PSE_band_calculation
-  case('GS')
+  case('GS') ! ground state
     call PSE_ground_state_calculation
     if(myrank == 0)then
       open(99,file="Vloc_gs.out",form='unformatted')
       write(99)Vloc
       close(99)
     end if
+  case('MS') ! Matrix element preparation
+    if(myrank == 0)then
+      open(99,file="Vloc_gs.out",form='unformatted')
+      read(99)Vloc
+      close(99)
+    end if
+    call MPI_BCAST(Vloc,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+    call PSE_preparation_basis_set
+
+  case('MT') ! prepare matrix elements
   case default
     err_message='invalid calc_mode'
     call err_finalize

--- a/src/preparation.f90
+++ b/src/preparation.f90
@@ -72,6 +72,7 @@ subroutine preparation
     read(*,*) Ncg,Nscf
     read(*,*) Nt,dt,Npred_corr
     read(*,*) option_TD_band_dos,Nstep_TD_band_dos
+    read(*,*) option_IP
     read(*,*) dAc
     read(*,*) laser_type,Tr_Lo
     read(*,*) IWcm2_1,tpulsefs_1,omegaev_1,phi_CEP_1
@@ -95,6 +96,7 @@ subroutine preparation
     write(*,'(A,2(2x,I0))') 'Ncg,Nscf = ',Ncg,Nscf
     write(*,'(A,2x,I0,2x,e16.6e3)') 'Nt,dt = ',Nt,dt
     write(*,'(A,2x,A,2x,I6)')'option_TD_band_dos,Nstep_TD_band_dos = ',option_TD_band_dos,Nstep_TD_band_dos
+    write(*,'(A,2x,A)')'option_IP = ',option_IP
     write(*,'(A,2x,e16.6e3)') 'dAc = ',dAc
     write(*,'(A,2x,A,2x,A)') 'laser_type, Tr_Lo = ',laser_type,Tr_Lo
     write(*,'(A,2x,4(2x,e16.6e3))') 'IWcm2_1,tpulsefs_1,omegaev_1,phi_CEP_1 = ',IWcm2_1,tpulsefs_1,omegaev_1,phi_CEP_1
@@ -132,6 +134,7 @@ subroutine preparation
   call MPI_BCAST(dt,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(option_TD_band_dos,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(Nstep_TD_band_dos,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+  call MPI_BCAST(option_IP,1,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(Npred_corr,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(dAc,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
   call MPI_BCAST(Tr_Lo,2,MPI_CHARACTER,0,MPI_COMM_WORLD,ierr)


### PR DESCRIPTION
I implemented the basis expansion method for the time-propagation of electron orbitals. The details of the method are described in Ref. [Phys. Rev. B 89, 224305 (2014)] .